### PR TITLE
fix python-psutil package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here is a small Python module for the PiGlow addon by Pimoroni, it will let you 
 ## Requirements
 
     sudo apt-get install python-smbus
-    sudo apt-get install python-psutils
+    sudo apt-get install python-psutil
 
 
 ## Functions


### PR DESCRIPTION
A 's' too much in the package name
